### PR TITLE
[0.4.0] pull request for issue #15: add parsing of duration strings to the time command

### DIFF
--- a/scripts/utils/time/checks.py
+++ b/scripts/utils/time/checks.py
@@ -1,10 +1,35 @@
 import re
 from scripts.utils.time.constants import VALID_TIMESTRING_REGEX
+from scripts.utils.time.constants import VALID_DURATION_REGEX
+from scripts.utils.time.constants import FINDALL_DURATION_REGEX
 
 def is_valid_time_string(checked_string):
   the_match = re.search(VALID_TIMESTRING_REGEX, checked_string)
 
   return True if the_match != None else False
 
+def is_valid_duration_string(checked_string):
+  the_match = re.search(VALID_DURATION_REGEX, checked_string)
+
+  if(the_match):
+    output = re.findall(FINDALL_DURATION_REGEX, checked_string)
+    return _is_findall_output_hms_balanced(output)
+
+  return False
+
 def is_of_type(the_value, the_type):
   return type(the_value) == the_type
+
+def _is_findall_output_hms_balanced(output):
+  hs = 0
+  ms = 0
+  ss = 0
+  for i in range(0, len(output)):
+    if 'h' in output[i][0]:
+      hs += 1
+    elif 'm' in output[i][0]:
+      ms += 1
+    elif 's' in output[i][0]:
+      ss += 1
+  return False if hs > 1 or ms > 1 or ss > 1 else True
+

--- a/scripts/utils/time/constants.py
+++ b/scripts/utils/time/constants.py
@@ -1,5 +1,8 @@
 VALID_TIMESTRING_REGEX = r'^(\d)+:(\d)+:(\d)+$'
 
+VALID_DURATION_REGEX = r'^(((\d)+[h|m|s]){0,1}){1,3}$'
+FINDALL_DURATION_REGEX = r'((\d)+[h|m|s])'
+
 TIME_UNIT_LENGTH_IN_SECONDS = 1500
 
 UNIFORM_TIME_STRING = '[{} U @ {:02d}:{:02d}:{:02d}]'

--- a/scripts/utils/time/conversions.py
+++ b/scripts/utils/time/conversions.py
@@ -1,13 +1,16 @@
 from datetime import timedelta
+import re
 
 from scripts.utils.time.checks import is_of_type
 from scripts.utils.time.checks import is_valid_time_string
+from scripts.utils.time.checks import is_valid_duration_string
 from scripts.utils.time.constants import TIME_UNIT_LENGTH_IN_SECONDS
 from scripts.utils.time.constants import UNIFORM_TIME_STRING
 from scripts.utils.time.constants import UNIFORM_TIME_STRING_DEFAULT
 from scripts.utils.time.constants import ROUND_UNITS_TO
 from scripts.utils.time.constants import SECONDS_IN_MINUTE
 from scripts.utils.time.constants import MINUTES_IN_HOUR
+from scripts.utils.time.constants import FINDALL_DURATION_REGEX
 from scripts.utils.utypes.ufloat.fractional import is_fractional_part_significant
 
 def check_float_validity_and_convert_from_string(source):
@@ -29,13 +32,33 @@ def convert_time_string_to_timedelta(source):
   (new_hours, new_minutes, new_seconds) = source.split(sep = ":")
   return timedelta(hours = int(new_hours), minutes = int(new_minutes), seconds = int(new_seconds))
 
+def convert_duration_string_to_timedelta(source):
+  if not is_valid_duration_string(source):
+    return None
+
+  output = re.findall(FINDALL_DURATION_REGEX, source)
+  hrs = 0
+  mins = 0
+  secs = 0
+  for i in range(0, len(output)):
+    if 'h' in output[i][0]:
+      hrs = int((output[i][0])[:-1]) # drop the last character [h|m|s] and convert to int
+    elif 'm' in output[i][0]:
+      mins = int((output[i][0])[:-1])
+    elif 's' in output[i][0]:
+      secs = int((output[i][0])[:-1])
+  
+  return timedelta(hours = hrs, minutes = mins, seconds = secs)
+
 def convert_to_timedelta(source):
   if is_of_type(source, int):
     return convert_float_to_timedelta(float(source))
   elif is_of_type(source, float):
     return convert_float_to_timedelta(source)
-  elif is_of_type(source, str):
+  elif is_of_type(source, str) and is_valid_time_string(source):
     return convert_time_string_to_timedelta(source)
+  elif is_of_type(source, str) and is_valid_duration_string(source):
+    return convert_duration_string_to_timedelta(source)
   else:
     return None
 

--- a/test/exploratory/etypes/estring/test_manipulations.py
+++ b/test/exploratory/etypes/estring/test_manipulations.py
@@ -18,6 +18,10 @@ class TestStringManipulations(unittest.TestCase):
     self.assertEqual(three, "two")
     self.assertEqual(items, "three")
 
+  def test_cropping_last_character(self):
+    self.assertEqual("Hell", str("Hello")[:-1])
+    self.assertEqual("Surpris", str("Surprise")[:-1])
+
   def tearDown(self):
       pass
 

--- a/test/unit/parsers/time/test_time_parser.py
+++ b/test/unit/parsers/time/test_time_parser.py
@@ -37,6 +37,10 @@ class TestTimeParser(unittest.TestCase):
     execution_result = self.parser.execute_command(parse_result)
     self.assertEqual(f'{ UNIFORM_TIME_STRING_DEFAULT }\n[2 U @ 00:50:00]\n[2.4 U @ 01:00:00]', execution_result)
 
+    parse_result = self.parser.parser.parse_args([self.parser.subcommand_name_print, "25h40m21s"])
+    execution_result = self.parser.execute_command(parse_result)
+    self.assertEqual('[61.614 U @ 25:40:21]', execution_result)
+
   def tearDown(self):
     pass
 

--- a/test/unit/utils/time/test_checks.py
+++ b/test/unit/utils/time/test_checks.py
@@ -2,6 +2,7 @@ import unittest
 from datetime import timedelta
 
 from scripts.utils.time.checks import is_valid_time_string
+from scripts.utils.time.checks import is_valid_duration_string
 from scripts.utils.time.checks import is_of_type
 
 class TestTimeChecks(unittest.TestCase):
@@ -32,6 +33,33 @@ class TestTimeChecks(unittest.TestCase):
     self.assertEqual(False, is_of_type(3, float))
     self.assertEqual(False, is_of_type(3.0, int))
     self.assertEqual(False, is_of_type("3.0", float))
+
+  def test_checks_duration_string(self):
+    self.assertEqual(True, is_valid_duration_string("1h"))
+    self.assertEqual(True, is_valid_duration_string("35h5m2s"))
+    self.assertEqual(True, is_valid_duration_string("2m34s"))
+    self.assertEqual(True, is_valid_duration_string("333h2222222m34343535s"))
+    self.assertEqual(True, is_valid_duration_string("5h25s"))
+    self.assertEqual(True, is_valid_duration_string("34s45h2m"))
+    self.assertEqual(True, is_valid_duration_string("1h25m"))
+    self.assertEqual(True, is_valid_duration_string("3m"))
+    self.assertEqual(True, is_valid_duration_string("44s"))
+
+    self.assertEqual(False, is_valid_duration_string("1h3.5m"))
+    self.assertEqual(False, is_valid_duration_string("1h2m3k"))
+    self.assertEqual(False, is_valid_duration_string("kk2mkk"))
+    self.assertEqual(False, is_valid_duration_string("hh2m1s"))
+    self.assertEqual(False, is_valid_duration_string("hhmmss"))
+    self.assertEqual(False, is_valid_duration_string("h1m2s"))
+    self.assertEqual(False, is_valid_duration_string(" h3m44s"))
+    self.assertEqual(False, is_valid_duration_string("1h1m2"))
+    self.assertEqual(False, is_valid_duration_string("1h1 2s"))
+    self.assertEqual(False, is_valid_duration_string("1h 2s"))
+    self.assertEqual(False, is_valid_duration_string(" "))
+    self.assertEqual(False, is_valid_duration_string("1m1m1m"))
+    self.assertEqual(False, is_valid_duration_string("1h1m1s1h"))
+    self.assertEqual(False, is_valid_duration_string("1s1s"))
+    self.assertEqual(False, is_valid_duration_string("1m1h1m"))
 
   def tearDown(self):
       pass

--- a/test/unit/utils/time/test_conversions.py
+++ b/test/unit/utils/time/test_conversions.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from scripts.utils.time.conversions import check_float_validity_and_convert_from_string
 from scripts.utils.time.conversions import convert_float_to_timedelta
 from scripts.utils.time.conversions import convert_time_string_to_timedelta
+from scripts.utils.time.conversions import convert_duration_string_to_timedelta
 from scripts.utils.time.conversions import convert_to_timedelta
 from scripts.utils.time.conversions import convert_timedelta_to_uniform_time_string
 from scripts.utils.time.constants import TIME_UNIT_LENGTH_IN_SECONDS
@@ -32,6 +33,17 @@ class TestConversions(unittest.TestCase):
     self.assertEqual(None, test_func("0k:12:48"))
     self.assertEqual(None, test_func("@@:$$:!!"))
 
+  def __duration_string_conversion_test(self, test_func):
+    self.assertEqual(timedelta(hours = 35, seconds = 3), test_func("35h3s"))
+    self.assertEqual(timedelta(hours = 2, minutes = 77, seconds = 3), test_func("2h77m3s"))
+    self.assertEqual(timedelta(hours = 2, minutes = 3, seconds = 1), test_func("1s2h3m"))
+    self.assertEqual(timedelta(hours = 2), test_func("2h"))
+    self.assertEqual(timedelta(hours = 1, minutes = 3), test_func("3m1h"))
+    self.assertEqual(timedelta(minutes = 160, seconds = 2440), test_func("160m2440s"))
+
+    self.assertEqual(None, test_func("1s2h3m1s"))
+    self.assertEqual(None, test_func("-1s"))
+
   def test_checks_float_validity(self):
     self.assertEqual(0.0, check_float_validity_and_convert_from_string("0"))
     self.assertEqual(0.765484612, check_float_validity_and_convert_from_string("0.765484612"))
@@ -51,9 +63,13 @@ class TestConversions(unittest.TestCase):
   def test_converts_time_string_to_timedelta(self):
     self.__time_string_conversion_test(test_func = convert_time_string_to_timedelta)
 
+  def test_converts_duration_string_to_timedelta(self):
+    self.__duration_string_conversion_test(test_func = convert_duration_string_to_timedelta)
+
   def test_converts_to_timedelta(self):
     self.__float_conversion_test(test_func = convert_to_timedelta)
     self.__time_string_conversion_test(test_func = convert_to_timedelta)
+    self.__duration_string_conversion_test(test_func = convert_to_timedelta)
 
   def test_converts_timedelta_to_uniform_time_string(self):
     self.assertEqual("[0 U @ 00:00:00]", 


### PR DESCRIPTION
This pull request adds duration strings of the following format to the time command:
`<X>h<Y>m<Z>s`, where X, Y and Z - number of hours, minutes and seconds respectively in a value that is to be converted to timedelta and printed out as a universal time string.
The order of hours, minutes and seconds and their combinations don't matter: there may only be hours, or hours and minutes, or minutes and seconds, etc.
**Valid duration strings:**
- `10h12m44s`
- `44m12h`
- `1s`
- `55555h44444m45454s`