### PR TITLE
[0.5.0] pull request for issue #18: add support for labels in universal time strings

### DIFF
--- a/scripts/calculate/pttime.py
+++ b/scripts/calculate/pttime.py
@@ -1,11 +1,14 @@
 from scripts.utils.time.conversions import convert_to_timedelta
 from scripts.utils.time.conversions import convert_timedelta_to_uniform_time_string
 from scripts.utils.time.constants import UNIFORM_TIME_STRING_DEFAULT
+from scripts.utils.time.constants import labeled_uniform_time_string_default
 
-def construct_uniform_time_string(source):
+def construct_uniform_time_string(source, label=None):
   source_timedelta = convert_to_timedelta(source)
 
-  if not source_timedelta:
+  if not source_timedelta and not label:
     return UNIFORM_TIME_STRING_DEFAULT
+  elif not source_timedelta and label:
+    return labeled_uniform_time_string_default(label)
 
-  return convert_timedelta_to_uniform_time_string(source_timedelta)
+  return convert_timedelta_to_uniform_time_string(source_timedelta, label)

--- a/scripts/parsers/time/time_parser.py
+++ b/scripts/parsers/time/time_parser.py
@@ -4,6 +4,8 @@ from scripts.parsers.base.abstract_parser import AbstractParser
 from scripts.utils.time.constants import TIME_COMMAND_DESCRIPTION
 from scripts.utils.time.constants import TIME_ARGUMENTS_TIME_HELP
 from scripts.utils.time.constants import TIME_ARGUMENTS_COMMAND_HELP
+from scripts.utils.time.constants import DEFAULT_LABEL
+from scripts.utils.time.constants import TIME_ARGUMENTS_LABEL_HELP
 from scripts.utils.constants import PARSER_IDENTIFIER_NAME
 from scripts.calculate.pttime import construct_uniform_time_string
 
@@ -14,6 +16,8 @@ class TimeParser(AbstractParser):
     self.short_name = "t"
     self.subcommand_name_print = "print"
     self.subcommand_short_name_print = "p"
+    self.optional_name_label = "--label"
+    self.optional_short_name_label = "-l"
 
   def _perform_creation(self):
     self.parser.description = TIME_COMMAND_DESCRIPTION
@@ -23,6 +27,7 @@ class TimeParser(AbstractParser):
                                   help=TIME_ARGUMENTS_COMMAND_HELP)
 
     self.parser.add_argument("time", nargs="+", help=TIME_ARGUMENTS_TIME_HELP)
+    self.parser.add_argument(self.optional_short_name_label, self.optional_name_label, nargs="?", const=DEFAULT_LABEL, help=TIME_ARGUMENTS_LABEL_HELP)
 
   def execute_command(self, parse_result):
     return self._get_subcommand_mapping()[parse_result.command](parse_result)
@@ -31,7 +36,10 @@ class TimeParser(AbstractParser):
     result = []
     for item in parse_result.time:
       item_ready = self._forward_number_from_argparse(item)
-      result += [construct_uniform_time_string(item_ready)]
+      if not parse_result.label:
+        result += [construct_uniform_time_string(item_ready)]
+      else:
+        result += [construct_uniform_time_string(item_ready, parse_result.label)]
 
     return '\n'.join(result)
 

--- a/scripts/utils/time/constants.py
+++ b/scripts/utils/time/constants.py
@@ -6,8 +6,12 @@ FINDALL_DURATION_REGEX = r'((\d)+[h|m|s])'
 TIME_UNIT_LENGTH_IN_SECONDS = 1500
 
 UNIFORM_TIME_STRING = '[{} U @ {:02d}:{:02d}:{:02d}]'
+LABELED_UNIFORM_TIME_STRING = '[{}: {} U @ {:02d}:{:02d}:{:02d}]'
+
 
 UNIFORM_TIME_STRING_DEFAULT = UNIFORM_TIME_STRING.format(0, 0, 0, 0)
+def labeled_uniform_time_string_default(label):
+  return LABELED_UNIFORM_TIME_STRING.format(label, 0, 0, 0, 0)
 
 ROUND_UNITS_TO = 3
 

--- a/scripts/utils/time/constants.py
+++ b/scripts/utils/time/constants.py
@@ -12,6 +12,7 @@ LABELED_UNIFORM_TIME_STRING = '[{}: {} U @ {:02d}:{:02d}:{:02d}]'
 UNIFORM_TIME_STRING_DEFAULT = UNIFORM_TIME_STRING.format(0, 0, 0, 0)
 def labeled_uniform_time_string_default(label):
   return LABELED_UNIFORM_TIME_STRING.format(label, 0, 0, 0, 0)
+DEFAULT_LABEL = 'WEIGHT'
 
 ROUND_UNITS_TO = 3
 
@@ -23,3 +24,4 @@ MINUTES_IN_HOUR = 60
 TIME_COMMAND_DESCRIPTION = "Time command is responsible for various calculations related to time.\nOutputs time in the format of a time string of '[<P> U @ HH:MM:SS]', where:\n<P> is a floating point number of pomodoro units the HH:MM:SS time string is equal to."
 TIME_ARGUMENTS_TIME_HELP = "Time to work with (one or more arguments expected).\nCan be either <HOURS>:<MINUTES>:<SECONDS> or <number_of_pomodoro_units>."
 TIME_ARGUMENTS_COMMAND_HELP = "Various subcommands the time command supports.\n\t=> print | p: print either HH:MM:SS or <P> as the [<P> U @ HH:MM:SS] time string."
+TIME_ARGUMENTS_LABEL_HELP = f"Add a helper label for clarification, so the output time string transforms to \n[<label>: <P> U @ HH:MM:SS]. Default label is '{DEFAULT_LABEL}'."

--- a/scripts/utils/time/conversions.py
+++ b/scripts/utils/time/conversions.py
@@ -6,7 +6,9 @@ from scripts.utils.time.checks import is_valid_time_string
 from scripts.utils.time.checks import is_valid_duration_string
 from scripts.utils.time.constants import TIME_UNIT_LENGTH_IN_SECONDS
 from scripts.utils.time.constants import UNIFORM_TIME_STRING
+from scripts.utils.time.constants import LABELED_UNIFORM_TIME_STRING
 from scripts.utils.time.constants import UNIFORM_TIME_STRING_DEFAULT
+from scripts.utils.time.constants import labeled_uniform_time_string_default
 from scripts.utils.time.constants import ROUND_UNITS_TO
 from scripts.utils.time.constants import SECONDS_IN_MINUTE
 from scripts.utils.time.constants import MINUTES_IN_HOUR
@@ -62,9 +64,9 @@ def convert_to_timedelta(source):
   else:
     return None
 
-def convert_timedelta_to_uniform_time_string(source_timedelta):
+def convert_timedelta_to_uniform_time_string(source_timedelta, label = None):
   if not is_of_type(source_timedelta, timedelta):
-    return UNIFORM_TIME_STRING_DEFAULT
+    return UNIFORM_TIME_STRING_DEFAULT if not label else labeled_uniform_time_string_default(label)
 
   total_seconds = round(source_timedelta.total_seconds())
   raw_units = total_seconds / TIME_UNIT_LENGTH_IN_SECONDS
@@ -76,4 +78,4 @@ def convert_timedelta_to_uniform_time_string(source_timedelta):
   (rest, secs) = divmod(total_seconds, SECONDS_IN_MINUTE)
   (hrs, mins) = divmod(rest, MINUTES_IN_HOUR)
 
-  return UNIFORM_TIME_STRING.format(units, hrs, mins, secs)
+  return UNIFORM_TIME_STRING.format(units, hrs, mins, secs) if not label else LABELED_UNIFORM_TIME_STRING.format(label, units, hrs, mins, secs)

--- a/test/unit/parsers/time/test_time_parser.py
+++ b/test/unit/parsers/time/test_time_parser.py
@@ -4,6 +4,8 @@ from scripts.parsers.base.abstract_parser import AbstractParser
 from scripts.parsers.time.time_parser import TimeParser
 from scripts.utils.constants import PARSER_IDENTIFIER_NAME
 from scripts.utils.time.constants import UNIFORM_TIME_STRING_DEFAULT
+from scripts.utils.time.constants import labeled_uniform_time_string_default
+from scripts.utils.time.constants import DEFAULT_LABEL
 
 class TestTimeParser(unittest.TestCase):
   
@@ -40,6 +42,30 @@ class TestTimeParser(unittest.TestCase):
     parse_result = self.parser.parser.parse_args([self.parser.subcommand_name_print, "25h40m21s"])
     execution_result = self.parser.execute_command(parse_result)
     self.assertEqual('[61.614 U @ 25:40:21]', execution_result)
+
+  def test_time_parser_executes_print_subcommand_with_label(self):
+    parse_result = self.parser.parser.parse_args([self.parser.optional_short_name_label, "kek", self.parser.subcommand_name_print, "00:25:00", "00:50:00", "108:64:1550"])
+    execution_result = self.parser.execute_command(parse_result)
+    self.assertEqual("[kek: 1 U @ 00:25:00]\n[kek: 2 U @ 00:50:00]\n[kek: 262.793 U @ 109:29:50]", execution_result)
+
+    parse_result = self.parser.parser.parse_args([self.parser.optional_name_label, "h@h@", self.parser.subcommand_name_print, "kek", "2", "1:00:0"])
+    execution_result = self.parser.execute_command(parse_result)
+    self.assertEqual(f'{ labeled_uniform_time_string_default("h@h@") }\n[h@h@: 2 U @ 00:50:00]\n[h@h@: 2.4 U @ 01:00:00]', execution_result)
+
+    parse_result = self.parser.parser.parse_args([self.parser.subcommand_name_print, "25h40m21s", self.parser.optional_short_name_label, "3"])
+    execution_result = self.parser.execute_command(parse_result)
+    self.assertEqual('[3: 61.614 U @ 25:40:21]', execution_result)
+
+    parse_result = self.parser.parser.parse_args([self.parser.optional_short_name_label, self.parser.subcommand_name_print, self.parser.subcommand_name_print, "25h40m21s"])
+    execution_result = self.parser.execute_command(parse_result)
+    self.assertEqual(f'[{self.parser.subcommand_name_print}: 61.614 U @ 25:40:21]', execution_result)
+
+    with self.assertRaises(ValueError):
+      parse_result = self.parser.parser.parse_args([self.parser.optional_short_name_label, self.parser.subcommand_name_print, "25h40m21s"])
+        
+    parse_result = self.parser.parser.parse_args([self.parser.subcommand_name_print, "25h40m21s", self.parser.optional_name_label])
+    execution_result = self.parser.execute_command(parse_result)
+    self.assertEqual(f'[{DEFAULT_LABEL}: 61.614 U @ 25:40:21]', execution_result)
 
   def tearDown(self):
     pass

--- a/test/unit/utils/time/test_conversions.py
+++ b/test/unit/utils/time/test_conversions.py
@@ -83,6 +83,18 @@ class TestConversions(unittest.TestCase):
     self.assertEqual("[295.432 U @ 123:05:48]",
       convert_timedelta_to_uniform_time_string(timedelta(seconds = 443148)))
 
+  def test_converts_timedelta_to_labeled_uniform_time_string(self):
+    self.assertEqual("[this: 0 U @ 00:00:00]", 
+      convert_timedelta_to_uniform_time_string(3, label = "this"))
+    self.assertEqual("[WEIGHT: 22 U @ 09:10:00]", 
+      convert_timedelta_to_uniform_time_string(timedelta(hours = 9, minutes = 10), label = "WEIGHT"))
+    self.assertEqual("[ke ke ke: 0 U @ 00:00:00]", 
+      convert_timedelta_to_uniform_time_string(timedelta(seconds = 0), label = "ke ke ke"))
+    self.assertEqual("[0 sOmE lAbEl $: 8.757 U @ 03:38:56]",
+      convert_timedelta_to_uniform_time_string(timedelta(hours = 3, minutes = 38, seconds = 56), label = "0 sOmE lAbEl $"))
+    self.assertEqual("[$#@!%: 295.432 U @ 123:05:48]",
+      convert_timedelta_to_uniform_time_string(timedelta(seconds = 443148), label = "$#@!%"))
+
   def tearDown(self):
     pass
 


### PR DESCRIPTION
Currently, the only format of a universal time string Purple Tools supports is

- `[X U @ HH:MM:SS]`

This issue pull request adds support for the following format as an optional --label argument:

- `[{label}: X U @ HH:MM:SS]`

To possibly add some clarification as to what this time string is referring to.
The default value of this argument is "WEIGHT".